### PR TITLE
Fixed loading issues with yaml files

### DIFF
--- a/greek_stemmer/__init__.py
+++ b/greek_stemmer/__init__.py
@@ -336,8 +336,8 @@ class GreekStemmer(object):
     def load_settings(self):
         custom_rules = ""
         with open(os.path.join(
-                  os.path.dirname(__file__), 'stemmer.yml'), 'r') as f:
-            custom_rules = yaml.load(f.read())
+                  os.path.dirname(__file__), 'stemmer.yml'), 'r', encoding='utf8') as f:
+            custom_rules = yaml.load(f.read(), Loader=yaml.FullLoader)
         return custom_rules
 
     def long_stem_list(self, word):


### PR DESCRIPTION
Some functions' default settings have changed and the module couldn't load. I explicitly define the yaml file encoding and loader which fixes the errors and warnings